### PR TITLE
Add ZITADEL_API_URL Environment Variable to Auth-UI Deployment Configuration

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               protocol: TCP
           env:
             - name: ZITADEL_API_URL
-              value: https://auth.staging.env.datum.net
+              value: https://auth.datum.net
           envFrom:
             # Add secret for ZITADEL_SERVICE_USER_TOKEN
             - secretRef:

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -35,8 +35,11 @@ spec:
             - containerPort: 3000
               name: http
               protocol: TCP
+          env:
+            - name: ZITADEL_API_URL
+              value: https://auth.staging.env.datum.net
           envFrom:
-            # Add secret for ZITADEL_SERVICE_USER_TOKEN and ZITADEL_API_URL
+            # Add secret for ZITADEL_SERVICE_USER_TOKEN
             - secretRef:
                 name: auth-ui
           resources:


### PR DESCRIPTION
This PR introduces the `ZITADEL_API_URL` environment variable to the auth-ui deployment configuration. Since `ZITADEL_API_URL` is not a sensitive value, it is set as a regular environment variable rather than a secret.