### PR TITLE
Conditionally render RegisterBtn based on loginSettings.allowRegister

### DIFF
--- a/apps/login/src/app/(main)/(illustration)/loginname/page.tsx
+++ b/apps/login/src/app/(main)/(illustration)/loginname/page.tsx
@@ -64,7 +64,6 @@ export default async function Page(props: {
       <p className="ztdl-p description">
         <Translated i18nKey="description" namespace="loginname" />
       </p>
-
       {loginSettings?.allowUsernamePassword && (
         <>
           <UsernameForm
@@ -83,7 +82,6 @@ export default async function Page(props: {
           )}
         </>
       )}
-
       {loginSettings?.allowExternalIdp && !!identityProviders.length && (
         <SignInWithIdp
           identityProviders={identityProviders}
@@ -91,7 +89,6 @@ export default async function Page(props: {
           organization={organization}
         ></SignInWithIdp>
       )}
-
       <p className="text-center ztdl-p-secondary terms-of-service">
         <Translated
           i18nKey="termsOfService"
@@ -99,8 +96,9 @@ export default async function Page(props: {
           useCommonTags
         />
       </p>
-
-      <RegisterBtn organization={organization} requestId={requestId} />
+      {loginSettings?.allowRegister && (
+        <RegisterBtn organization={organization} requestId={requestId} />
+      )}
     </>
   );
 }

--- a/apps/login/src/app/(main)/(illustration)/loginname/page.tsx
+++ b/apps/login/src/app/(main)/(illustration)/loginname/page.tsx
@@ -64,6 +64,7 @@ export default async function Page(props: {
       <p className="ztdl-p description">
         <Translated i18nKey="description" namespace="loginname" />
       </p>
+
       {loginSettings?.allowUsernamePassword && (
         <>
           <UsernameForm
@@ -82,6 +83,7 @@ export default async function Page(props: {
           )}
         </>
       )}
+
       {loginSettings?.allowExternalIdp && !!identityProviders.length && (
         <SignInWithIdp
           identityProviders={identityProviders}
@@ -89,6 +91,7 @@ export default async function Page(props: {
           organization={organization}
         ></SignInWithIdp>
       )}
+
       <p className="text-center ztdl-p-secondary terms-of-service">
         <Translated
           i18nKey="termsOfService"
@@ -96,9 +99,8 @@ export default async function Page(props: {
           useCommonTags
         />
       </p>
-      {loginSettings?.allowRegister && (
-        <RegisterBtn organization={organization} requestId={requestId} />
-      )}
+
+      <RegisterBtn organization={organization} requestId={requestId} />
     </>
   );
 }

--- a/apps/login/src/app/(main)/(illustration)/register/page.tsx
+++ b/apps/login/src/app/(main)/(illustration)/register/page.tsx
@@ -55,19 +55,6 @@ export default async function Page(props: {
     });
   });
 
-  if (!loginSettings?.allowRegister) {
-    return (
-      <>
-        <h1>
-          <Translated i18nKey="disabled.title" namespace="register" />
-        </h1>
-        <p className="ztdl-p">
-          <Translated i18nKey="disabled.description" namespace="register" />
-        </p>
-      </>
-    );
-  }
-
   return (
     <>
       <h1>
@@ -83,7 +70,8 @@ export default async function Page(props: {
         </Alert>
       )}
 
-      {passwordComplexitySettings &&
+      {loginSettings?.allowRegister &&
+        passwordComplexitySettings &&
         organization &&
         (loginSettings.allowUsernamePassword ||
           loginSettings.passkeysType == PasskeysType.ALLOWED) && (


### PR DESCRIPTION
This PR updates `loginname` page to conditionally render the `RegisterBtn` based on the Zitadel instance configuration.
