### PR TITLE
docs: fix typo in GitHub email-fetch comment

### DIFF
--- a/apps/login/src/app/(main)/(boxed)/idp/[provider]/success/page.tsx
+++ b/apps/login/src/app/(main)/(boxed)/idp/[provider]/success/page.tsx
@@ -69,7 +69,7 @@ async function resolveOrganizationForUser({
 
 type GithubEmailInfo = { email: string; verified: boolean } | undefined;
 
-// getGithunPrimaryEmail fetches the primary email, even if the user has hidden it
+// getGithubPrimaryEmail fetches the primary email, even if the user has hidden it
 // user:email scope is required for private emails
 async function getGithubPrimaryEmail(token: string): Promise<GithubEmailInfo> {
   const fetchEmails = async () => {


### PR DESCRIPTION
This PR replaces `getGithunPrimaryEmail` with `getGithubPrimaryEmail`.

The comment’s typo (“Githun”) didn’t match the actual function name `getGithubPrimaryEmail`, so it was corrected for consistency.

No functional changes—just keeps the codebase tidy and avoids confusion.