### PR TITLE
Remove Login button from registration page

### DIFF
--- a/apps/login/src/app/(main)/(illustration)/register/page.tsx
+++ b/apps/login/src/app/(main)/(illustration)/register/page.tsx
@@ -13,7 +13,6 @@ import {
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import { PasskeysType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import { headers } from "next/headers";
-import { LoginBtn } from "./_login-btn";
 
 export const metadata = generateRouteMetadata("register");
 
@@ -103,7 +102,7 @@ export default async function Page(props: {
         ></SignInWithIdp>
       )}
 
-      <LoginBtn />
+      {/* <LoginBtn /> */}
     </>
   );
 }


### PR DESCRIPTION
This PR removes the login button from the registration page.

Since users won’t be able to log in until they’re approved at launch, the button would only cause confusion.

A dedicated login page already exists, so this streamlines the flow and reduces redundant UI elements.

Requested here: 
https://datum-inc.slack.com/archives/C084W6XRVS7/p1763148394745509