### PR TITLE
fix: improve error handling and loading state

### DIFF
--- a/apps/login/src/app/(main)/(boxed)/accounts/page.tsx
+++ b/apps/login/src/app/(main)/(boxed)/accounts/page.tsx
@@ -11,11 +11,12 @@ import {
 import { UserPlusIcon } from "@heroicons/react/24/outline";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import clsx from "clsx";
+import { Metadata } from "next";
 import { getLocale } from "next-intl/server";
 import { headers } from "next/headers";
 import Link from "next/link";
 
-export const metadata = generateRouteMetadata("accounts");
+export const metadata: Metadata = generateRouteMetadata("accounts");
 
 async function loadSessions({ serviceUrl }: { serviceUrl: string }) {
   const ids: (string | undefined)[] = await getAllSessionCookieIds();

--- a/apps/login/src/components/avatar.tsx
+++ b/apps/login/src/components/avatar.tsx
@@ -64,6 +64,7 @@ export function Avatar({
 
   return (
     <div
+      suppressHydrationWarning
       className={`w-full h-full flex-shrink-0 flex justify-center items-center cursor-default pointer-events-none group-focus:outline-none group-focus:ring-2 transition-colors duration-200 dark:group-focus:ring-offset-blue bg-primary-light-500 text-primary-light-contrast-500 hover:bg-primary-light-400 hover:dark:bg-primary-dark-500 group-focus:ring-primary-light-200 dark:group-focus:ring-primary-dark-400 dark:bg-primary-dark-300 dark:text-primary-dark-contrast-300 dark:text-blue rounded-full ${
         shadow ? "shadow" : ""
       } ${

--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -8,7 +8,7 @@ import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import moment from "moment";
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { Avatar } from "./avatar";
 
 export function isSessionValid(session: Partial<Session>): {
@@ -38,71 +38,88 @@ export function SessionItem({
   reload: () => void;
   requestId?: string;
 }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const currentLocale = useLocale();
+  const { valid, verifiedAt } = isSessionValid(session);
+  const [error, setError] = useState<string | null>(null);
   moment.locale(currentLocale === "zh" ? "zh-cn" : currentLocale);
 
-  const [loading, setLoading] = useState<boolean>(false);
-
   async function clearSessionId(id: string) {
-    setLoading(true);
+    setError(null);
     const response = await clearSession({
       sessionId: id,
-    })
-      .catch((error) => {
-        setError(error.message);
-        return;
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    }).catch((error) => {
+      setError(error.message);
+      return;
+    });
 
     return response;
   }
 
-  const { valid, verifiedAt } = isSessionValid(session);
+  function handleClick() {
+    startTransition(async () => {
+      setError(null);
 
-  const [error, setError] = useState<string | null>(null);
+      if (isPending) return;
 
-  const router = useRouter();
-
-  return (
-    <button
-      onClick={async () => {
-        if (valid && session?.factors?.user) {
+      if (valid && session?.factors?.user) {
+        try {
           const resp = await continueWithSession({
             ...session,
             requestId: requestId,
           });
 
           if (resp?.redirect) {
-            return router.push(resp.redirect);
-          }
-        } else if (session.factors?.user) {
-          setLoading(true);
-          const res = await sendLoginname({
-            loginName: session.factors?.user?.loginName,
-            organization: session.factors.user.organizationId,
-            requestId: requestId,
-          })
-            .catch(() => {
-              setError("An internal error occurred");
-              return;
-            })
-            .finally(() => {
-              setLoading(false);
-            });
-
-          if (res && "redirect" in res && res.redirect) {
-            return router.push(res.redirect);
-          }
-
-          if (res && "error" in res && res.error) {
-            setError(res.error);
+            router.push(resp.redirect);
+            return;
+          } else {
+            setError("Could not continue with session. Please try again.");
             return;
           }
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : "An internal error occurred",
+          );
+          return;
         }
-      }}
-      className="group flex flex-row items-center py-2 border border-light-gray hover:border-navy rounded-lg bg-background-light-400 dark:bg-background-dark-400 transition-all px-4"
+      } else if (session.factors?.user) {
+        const res = await sendLoginname({
+          loginName: session.factors?.user?.loginName,
+          organization: session.factors.user.organizationId,
+          requestId: requestId,
+        }).catch(() => {
+          setError("An internal error occurred");
+          return;
+        });
+
+        if (res && "redirect" in res && res.redirect) {
+          router.push(res.redirect);
+          return;
+        }
+
+        if (res && "error" in res && res.error) {
+          setError(res.error);
+          return;
+        }
+
+        // If we get here, no redirect or error was returned
+        if (res) {
+          setError("Could not process login. Please try again.");
+          return;
+        }
+      } else {
+        setError("Could not process login. Please try again.");
+        return;
+      }
+    });
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isPending}
+      className="group flex flex-row items-center py-2 border border-light-gray hover:border-navy rounded-lg bg-background-light-400 dark:bg-background-dark-400 transition-all px-4 disabled:opacity-50 disabled:cursor-not-allowed"
     >
       <div className="pr-2.5">
         <Avatar
@@ -112,14 +129,18 @@ export function SessionItem({
         />
       </div>
 
-      <div className="flex flex-col items-start overflow-hidden">
+      <div className="flex flex-col items-start overflow-hidden flex-1 min-w-0">
         <span className="font-semibold text-sm">
           {session.factors?.user?.displayName}
         </span>
         <span className="text-xs text-navy opacity-60 text-ellipsis font-normal">
           {session.factors?.user?.loginName}
         </span>
-        {valid ? (
+        {error ? (
+          <span className="text-xs text-red-500 text-ellipsis text-left pt-2 max-w-52">
+            {error}
+          </span>
+        ) : valid ? (
           <span className="text-xs text-navy opacity-60 text-ellipsis">
             {verifiedAt && moment(timestampDate(verifiedAt)).fromNow()}
           </span>
@@ -134,24 +155,29 @@ export function SessionItem({
         )}
       </div>
 
-      <span className="flex-grow"></span>
       <div className="relative flex flex-row items-center">
-        {valid ? (
-          <div className="absolute h-2 w-2 bg-green-500 rounded-full mx-2 transform right-0 group-hover:right-6 transition-all"></div>
+        {isPending ? (
+          <div className="h-4 w-4 border-2 border-navy border-t-transparent rounded-full animate-spin mx-2"></div>
         ) : (
-          <div className="absolute h-2 w-2 bg-red-500 rounded-full mx-2 transform right-0 group-hover:right-6 transition-all"></div>
-        )}
+          <>
+            {valid ? (
+              <div className="absolute h-2 w-2 bg-green-500 rounded-full mx-2 transform right-0 group-hover:right-6 transition-all"></div>
+            ) : (
+              <div className="absolute h-2 w-2 bg-red-500 rounded-full mx-2 transform right-0 group-hover:right-6 transition-all"></div>
+            )}
 
-        <XCircleIcon
-          className="hidden group-hover:block h-5 w-5 transition-all opacity-50 hover:opacity-100"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            clearSessionId(session.id).then(() => {
-              reload();
-            });
-          }}
-        />
+            <XCircleIcon
+              className="hidden group-hover:block h-5 w-5 transition-all opacity-50 hover:opacity-100"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                clearSessionId(session.id).then(() => {
+                  reload();
+                });
+              }}
+            />
+          </>
+        )}
       </div>
     </button>
   );

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -100,9 +100,12 @@ export async function continueWithSession({
             loginSettings?.defaultRedirectUri,
           )
         : null;
-  if (url) {
-    return { redirect: url };
+
+  if (!url) {
+    console.error("Could not get next url", { requestId, session });
   }
+
+  return url ? { redirect: url } : null;
 }
 
 export type UpdateSessionCommand = {


### PR DESCRIPTION
Sometimes when on the `accounts` route when you click your account it can silently [fail](https://github.com/datum-cloud/cloud-portal/issues/844#issuecomment-3697104035) and give you no feedback, loading state or error message. This PR improves the loading state and error handling, it will always show you a message if the redirect url can't be constructed for whatever reason. 

Also improved the loading state when logging in from the main login route. 

https://github.com/user-attachments/assets/fd70fcbf-f052-4542-afbf-f650ad5d75d1


https://github.com/user-attachments/assets/d6b6d532-fefe-4234-b11d-9ca06fd06efc

