### PR TITLE
feat: make IDP unlinking configurable via env var

### DIFF
--- a/apps/login/src/app/(main)/(boxed)/idp/link/page.tsx
+++ b/apps/login/src/app/(main)/(boxed)/idp/link/page.tsx
@@ -163,7 +163,10 @@ export default async function Page(props: {
             />
           </h2>
           <ul className="space-y-2">
-            <LinkedIdpList linkedIdps={linkedIdps} />
+            <LinkedIdpList
+              linkedIdps={linkedIdps}
+              allowUnlink={process.env.ALLOW_IDP_UNLINK === "true"}
+            />
           </ul>
         </div>
       )}

--- a/apps/login/src/components/button.tsx
+++ b/apps/login/src/components/button.tsx
@@ -35,8 +35,7 @@ export const getButtonClasses = (
   color: ButtonColors,
 ) =>
   clsx({
-    "box-border font-normal text-button-foreground text-center justify-center leading-36px inline-flex items-center rounded-md focus:outline-none transition-colors transition-shadow duration-300":
-      true,
+    "box-border font-normal text-button-foreground text-center justify-center leading-36px inline-flex items-center rounded-md focus:outline-none transition-colors transition-shadow duration-300": true,
     "bg-button-primary-background text-button-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed hover:opacity-90 focus:opacity-80 disabled:pointer-events-none transition-all":
       variant === ButtonVariants.Primary,
     "bg-button-ghost-background border-none shadow-none text-button-ghost-foreground underline hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed":

--- a/apps/login/src/components/input.tsx
+++ b/apps/login/src/components/input.tsx
@@ -27,10 +27,8 @@ export type TextInputProps = DetailedHTMLProps<
 
 const styles = (error: boolean, disabled: boolean) =>
   clsx({
-    "box-border flex flex-row items-center px-4 py-2 w-full bg-input-background border border-input-border rounded-md transition-colors duration-300 opacity-100":
-      true,
-    "focus:outline-none focus:ring-0 focus:border-input-focus focus:!shadow-[0_0_0_2px_rgba(77,99,86,0.15)] text-input-foreground placeholder:text-input-foreground placeholder:opacity-60":
-      true,
+    "box-border flex flex-row items-center px-4 py-2 w-full bg-input-background border border-input-border rounded-md transition-colors duration-300 opacity-100": true,
+    "focus:outline-none focus:ring-0 focus:border-input-focus focus:!shadow-[0_0_0_2px_rgba(77,99,86,0.15)] text-input-foreground placeholder:text-input-foreground placeholder:opacity-60": true,
     "border-warn-light-500 dark:border-warn-dark-500 hover:border-warn-light-500 hover:dark:border-warn-dark-500 focus:border-warn-light-500 focus:dark:border-warn-dark-500":
       error,
     "pointer-events-none opacity-50 cursor-default": disabled,

--- a/apps/login/src/components/linked-idp-list.tsx
+++ b/apps/login/src/components/linked-idp-list.tsx
@@ -15,9 +15,10 @@ export type LinkedIdp = {
 
 type Props = {
   linkedIdps: LinkedIdp[];
+  allowUnlink?: boolean;
 };
 
-export function LinkedIdpList({ linkedIdps }: Props) {
+export function LinkedIdpList({ linkedIdps, allowUnlink = false }: Props) {
   return (
     <ul className="space-y-2 w-full">
       {linkedIdps.map((l) => {
@@ -88,15 +89,17 @@ export function LinkedIdpList({ linkedIdps }: Props) {
               </div>
             </div>
 
-            <div className="shrink-0">
-              <UnlinkIdpButton
-                unlinkAction={unlinkIdp}
-                idpId={l.idpId}
-                linkedUserId={l.linkedUserId}
-                providerName={l.idpName}
-                isLastIdp={linkedIdps.length === 1}
-              />
-            </div>
+            {allowUnlink && (
+              <div className="shrink-0">
+                <UnlinkIdpButton
+                  unlinkAction={unlinkIdp}
+                  idpId={l.idpId}
+                  linkedUserId={l.linkedUserId}
+                  providerName={l.idpName}
+                  isLastIdp={linkedIdps.length === 1}
+                />
+              </div>
+            )}
           </li>
         );
       })}

--- a/apps/login/src/components/state-badge.tsx
+++ b/apps/login/src/components/state-badge.tsx
@@ -16,8 +16,7 @@ export type StateBadgeProps = {
 
 const getBadgeClasses = (state: BadgeState, evenPadding: boolean) =>
   clsx({
-    "w-fit border-box h-18 w-18 flex flex-row items-center whitespace-nowrap tracking-wider leading-4 items-center justify-center px-2 py-2px text-12px rounded-full shadow-sm":
-      true,
+    "w-fit border-box h-18 w-18 flex flex-row items-center whitespace-nowrap tracking-wider leading-4 items-center justify-center px-2 py-2px text-12px rounded-full shadow-sm": true,
     "bg-state-success-light-background text-state-success-light-color dark:bg-state-success-dark-background dark:text-state-success-dark-color ":
       state === BadgeState.Success,
     "bg-state-neutral-light-background text-state-neutral-light-color dark:bg-state-neutral-dark-background dark:text-state-neutral-dark-color":

--- a/apps/login/src/lib/server/idp.ts
+++ b/apps/login/src/lib/server/idp.ts
@@ -273,6 +273,11 @@ export async function createNewSessionForLDAP(
 }
 
 export async function unlinkIdp(formData: FormData) {
+  if (process.env.ALLOW_IDP_UNLINK !== "true") {
+    console.warn("Attempt to unlink IDP while feature is disabled");
+    return;
+  }
+
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           env:
             - name: ZITADEL_API_URL
               value: https://auth.datum.net
+            - name: ALLOW_IDP_UNLINK
+              value: "false"
           envFrom:
             # Add secret for ZITADEL_SERVICE_USER_TOKEN
             - secretRef:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": [
+    "**/.env.*local"
+  ],
   "globalEnv": [
     "DEBUG",
     "VERCEL_URL",
@@ -16,7 +18,8 @@
     "ENABLE_ZITADEL_API_TRANSLATION",
     "NODE_ENV",
     "MARKER_IO_PROJECT_ID",
-    "FATHOM_ID"
+    "FATHOM_ID",
+    "ALLOW_IDP_UNLINK"
   ],
   "tasks": {
     "generate": {
@@ -32,11 +35,15 @@
     "test:unit:standalone": {},
     "test:integration": {},
     "test:integration:setup": {
-      "with": ["dev"]
+      "with": [
+        "dev"
+      ]
     },
     "test:acceptance:setup": {},
     "test:acceptance:setup:dev": {
-      "with": ["dev"]
+      "with": [
+        "dev"
+      ]
     },
     "test:watch": {
       "persistent": true


### PR DESCRIPTION
This PR introduces the `ALLOW_IDP_UNLINK` environment variable to securely control whether users can unlink Identity Providers directly from the UI.

**Context & Motivation**: When an IDP link is removed, the user's email address must be updated if the deleted IDP was the source of that email. To ensure data consistency, this responsibility is being offloaded to a Milo API, which will contain the logic to verify that a user's email matches one of their remaining linked IDPs.

By gating this feature behind an environment variable, we can disable direct unlinking in the Auth UI and ensure all unlinking operations go through the appropriate controlled flows.
