### PR TITLE
feat: Fix "User not found" error for expired IDP sessions

### DIFF
--- a/apps/login/src/components/session-item.tsx
+++ b/apps/login/src/components/session-item.tsx
@@ -88,6 +88,7 @@ export function SessionItem({
           loginName: session.factors?.user?.loginName,
           organization: session.factors.user.organizationId,
           requestId: requestId,
+          userId: session.factors?.user?.id, // Pass userId to handle IDP users
         }).catch(() => {
           setError("An internal error occurred");
           return;

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -28,6 +28,7 @@ export type SendLoginnameCommand = {
   requestId?: string;
   organization?: string;
   suffix?: string;
+  userId?: string; // Optional: when provided, used to get user email if loginName search fails
 };
 
 const ORG_SUFFIX_REGEX = /(?<=@)(.+)/;
@@ -56,6 +57,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     organizationId: command.organization,
     loginSettings: loginSettingsByContext,
     suffix: command.suffix,
+    userId: command.userId, // Pass userId for email lookup if loginName search fails
   };
 
   const searchResult = await searchUsers(searchUsersRequest);


### PR DESCRIPTION
Description: Fixed an issue where users authenticated via identity providers (IDP) encountered a "User not found in the system" error when interacting with expired sessions on the /accounts page.

This was caused by the session storing an IDP-specific username (e.g., GitHub handle) as the loginName, which is not directly searchable in ZITADEL when both email and phone login methods are disabled.

Relates to: https://github.com/datum-cloud/auth-ui/issues/42