### PR TITLE
fix: device consent page internationalization issue

### DIFF
--- a/apps/login/src/components/consent.tsx
+++ b/apps/login/src/components/consent.tsx
@@ -96,7 +96,7 @@ export function ConsentScreen({
           data-testid="deny-button"
         >
           {loading && <Spinner className="h-5 w-5 mr-2" />}
-          <Translated i18nKey="device.request.deny" namespace="device" />
+          <Translated i18nKey="request.deny" namespace="device" />
         </Button>
         <span className="flex-grow"></span>
 
@@ -107,7 +107,7 @@ export function ConsentScreen({
             className="self-end"
             variant={ButtonVariants.Primary}
           >
-            <Translated i18nKey="device.request.submit" namespace="device" />
+            <Translated i18nKey="request.submit" namespace="device" />
           </Button>
         </Link>
       </div>


### PR DESCRIPTION
The device authentication page uses the Consent component but it looks
like this component has an issue related to internalization.

On screen the two buttons did not look nice
