### PR TITLE
fix(proxy): strip malformed Next-Router-State-Tree headers 

### DIFF
--- a/apps/login/src/proxy.ts
+++ b/apps/login/src/proxy.ts
@@ -42,6 +42,25 @@ export async function proxy(request: NextRequest) {
   // Add the original URL as a header to all requests
   const requestHeaders = new Headers(request.headers);
 
+  // Strip malformed Next-Router-State-Tree headers to prevent Next.js from
+  // throwing "The router state header was sent but could not be parsed."
+  // This happens when stale clients (pre-deployment) send incomplete router state.
+  const routerStateHeader = requestHeaders.get("Next-Router-State-Tree");
+  if (routerStateHeader) {
+    let isValid = false;
+    try {
+      const parsed = JSON.parse(decodeURIComponent(routerStateHeader));
+      isValid = Array.isArray(parsed) && parsed.length >= 2;
+    } catch {
+      isValid = false;
+    }
+    if (!isValid) {
+      requestHeaders.delete("Next-Router-State-Tree");
+      requestHeaders.delete("Rsc");
+      requestHeaders.delete("Next-Router-Prefetch");
+    }
+  }
+
   // Extract "organization" search param from the URL and set it as a header if available
   const organization = request.nextUrl.searchParams.get("organization");
   if (organization) {


### PR DESCRIPTION
## Problem                                                                                                                                                                 
   
  After deployments, clients that had the login page open retain stale router state.                                                                                         
  When they navigate, Next.js App Router sends an RSC request with a malformed                                                                                             
  `Next-Router-State-Tree` header — specifically `[""]` instead of the full routing
  tree. Next.js fails to parse this and throws an unhandled error:                                                                                                           
   
  > Error: The router state header was sent but could not be parsed.                                                                                                         
                                                                                                                                                                           
  This surfaces on the `/(main)/(illustration)/loginname/page` route and is tracked                                                                                          
  in Sentry:
  https://sentry.prod.env.datum.net/organizations/sentry/issues/1918/events/105a342aff4e46f8946d950cb8c6a6bc/                                                                
                                                                                                                                                                             
  ## Fix
                                                                                                                                                                             
  Added a check in `proxy.ts` that validates the `Next-Router-State-Tree` header                                                                                           
  before the request reaches the Next.js rendering pipeline. If the value cannot be
  parsed as JSON or is structurally incomplete (fewer than 2 elements), the RSC-related
  headers (`Next-Router-State-Tree`, `Rsc`, `Next-Router-Prefetch`) are stripped.                                                                                            
   
  Without these headers, Next.js falls back to a full SSR page render, which resets                                                                                          
  the client's router state and serves the page correctly.                                                                                                                 
                                                                                                                                                                             
  ## Impact on normal users                                                                                                                                                

  - **Normal full page loads** — no `Next-Router-State-Tree` header present, code is a no-op.                                                                                
  - **Normal RSC navigations** — header parses correctly with 2+ elements, nothing is stripped.
  - **Stale clients** — headers stripped, user gets a full page load instead of an error.  