### PR TITLE
fix: handle missing OIDC auth request gracefully

### DIFF
--- a/apps/login/src/app/(main)/(boxed)/error/page.tsx
+++ b/apps/login/src/app/(main)/(boxed)/error/page.tsx
@@ -1,0 +1,19 @@
+import { Alert, AlertType } from "@/components/alert";
+
+export default async function Page(props: {
+  searchParams: Promise<Record<string | number | symbol, string | undefined>>;
+}) {
+  const searchParams = await props.searchParams;
+  const title = searchParams.title ?? "Something went wrong";
+  const message =
+    searchParams.error ?? "An unexpected error occurred. Please try again.";
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      <div className="pt-6">
+        <Alert type={AlertType.ALERT}>{message}</Alert>
+      </div>
+    </>
+  );
+}

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -16,7 +16,7 @@ import {
   listSessions,
   startIdentityProviderFlow,
 } from "@/lib/zitadel";
-import { ConnectError, create } from "@zitadel/client";
+import { create } from "@zitadel/client";
 import { Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
 import {
   CreateCallbackRequestSchema,
@@ -48,19 +48,26 @@ const gotoError = ({
 };
 
 const getAuthRequestErrorMessage = (error: unknown): string => {
-  if (error instanceof ConnectError) {
-    switch (error.code) {
-      case 5: // NOT_FOUND
-        return "Your login session has expired. Please return to the application and try signing in again.";
-      case 7: // PERMISSION_DENIED
-        return "You don't have permission to access this login request. Please contact your administrator.";
-      case 14: // UNAVAILABLE
-        return "The authentication service is temporarily unavailable. Please try again in a few moments.";
-      case 4: // DEADLINE_EXCEEDED
-        return "The authentication service took too long to respond. Please try again.";
-    }
+  const code =
+    error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { code: unknown }).code === "number"
+      ? (error as { code: number }).code
+      : undefined;
+
+  switch (code) {
+    case 5: // NOT_FOUND
+      return "Your login session has expired. Please return to the application and try signing in again.";
+    case 7: // PERMISSION_DENIED
+      return "You don't have permission to access this login request. Please contact your administrator.";
+    case 14: // UNAVAILABLE
+      return "The authentication service is temporarily unavailable. Please try again in a few moments.";
+    case 4: // DEADLINE_EXCEEDED
+      return "The authentication service took too long to respond. Please try again.";
+    default:
+      return "Your login request could not be found or has expired. Please return to the application and try signing in again.";
   }
-  return "Your login request could not be found or has expired. Please return to the application and try signing in again.";
 };
 
 const gotoAccounts = ({

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -16,7 +16,7 @@ import {
   listSessions,
   startIdentityProviderFlow,
 } from "@/lib/zitadel";
-import { create } from "@zitadel/client";
+import { ConnectError, create } from "@zitadel/client";
 import { Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
 import {
   CreateCallbackRequestSchema,
@@ -31,6 +31,37 @@ import { DEFAULT_CSP } from "../../../constants/csp";
 
 // NOTE: Route segment configs (dynamic, revalidate, fetchCache) removed for Next.js 15.6+ compatibility
 // With dynamicIO enabled, route handlers are dynamic by default
+
+const gotoError = ({
+  request,
+  title,
+  error,
+}: {
+  request: NextRequest;
+  title: string;
+  error: string;
+}): NextResponse<unknown> => {
+  const errorUrl = constructUrl(request, "/error");
+  errorUrl.searchParams.set("title", title);
+  errorUrl.searchParams.set("error", error);
+  return NextResponse.redirect(errorUrl);
+};
+
+const getAuthRequestErrorMessage = (error: unknown): string => {
+  if (error instanceof ConnectError) {
+    switch (error.code) {
+      case 5: // NOT_FOUND
+        return "Your login session has expired. Please return to the application and try signing in again.";
+      case 7: // PERMISSION_DENIED
+        return "You don't have permission to access this login request. Please contact your administrator.";
+      case 14: // UNAVAILABLE
+        return "The authentication service is temporarily unavailable. Please try again in a few moments.";
+      case 4: // DEADLINE_EXCEEDED
+        return "The authentication service took too long to respond. Please try again.";
+    }
+  }
+  return "Your login request could not be found or has expired. Please return to the application and try signing in again.";
+};
 
 const gotoAccounts = ({
   request,
@@ -142,17 +173,20 @@ export async function GET(request: NextRequest) {
       }));
     } catch (error) {
       console.error("Failed to get auth request:", error);
-      return NextResponse.json(
-        { error: "Auth request not found or expired" },
-        { status: 400 },
-      );
+      return gotoError({
+        request,
+        title: "Login request expired",
+        error: getAuthRequestErrorMessage(error),
+      });
     }
 
     if (!authRequest) {
-      return NextResponse.json(
-        { error: "Auth request not found" },
-        { status: 400 },
-      );
+      return gotoError({
+        request,
+        title: "Login request not found",
+        error:
+          "Your login request could not be found. Please return to the application and try signing in again.",
+      });
     }
 
     let organization = "";
@@ -248,10 +282,12 @@ export async function GET(request: NextRequest) {
           });
 
           if (!url) {
-            return NextResponse.json(
-              { error: "Could not start IDP flow" },
-              { status: 500 },
-            );
+            return gotoError({
+              request,
+              title: "Sign-in unavailable",
+              error:
+                "We couldn't connect to your identity provider. Please try again or contact your administrator.",
+            });
           }
 
           if (url.startsWith("/")) {
@@ -487,10 +523,12 @@ export async function GET(request: NextRequest) {
     });
 
     if (!samlRequest) {
-      return NextResponse.json(
-        { error: "No samlRequest found" },
-        { status: 400 },
-      );
+      return gotoError({
+        request,
+        title: "Login request not found",
+        error:
+          "Your SAML login request could not be found or has expired. Please return to the application and try signing in again.",
+      });
     }
 
     let selectedSession = await findValidSession({
@@ -574,9 +612,11 @@ export async function GET(request: NextRequest) {
   }
   // Device Authorization does not need to start here as it is handled on the /device endpoint
   else {
-    return NextResponse.json(
-      { error: "No authRequest nor samlRequest provided" },
-      { status: 500 },
-    );
+    return gotoError({
+      request,
+      title: "No login request",
+      error:
+        "No authentication request was provided. Please start the sign-in process from your application.",
+    });
   }
 }

--- a/apps/login/src/app/login/route.ts
+++ b/apps/login/src/app/login/route.ts
@@ -134,10 +134,26 @@ export async function GET(request: NextRequest) {
 
   // continue with OIDC
   if (requestId && requestId.startsWith("oidc_")) {
-    const { authRequest } = await getAuthRequest({
-      serviceUrl,
-      authRequestId: requestId.replace("oidc_", ""),
-    });
+    let authRequest;
+    try {
+      ({ authRequest } = await getAuthRequest({
+        serviceUrl,
+        authRequestId: requestId.replace("oidc_", ""),
+      }));
+    } catch (error) {
+      console.error("Failed to get auth request:", error);
+      return NextResponse.json(
+        { error: "Auth request not found or expired" },
+        { status: 400 },
+      );
+    }
+
+    if (!authRequest) {
+      return NextResponse.json(
+        { error: "Auth request not found" },
+        { status: 400 },
+      );
+    }
 
     let organization = "";
     let suffix = "";


### PR DESCRIPTION
The GET /login route called getAuthRequest() without error handling. When a request arrived with an expired or invalid authRequest ID, the Zitadel OIDC service returned a NOT_FOUND gRPC error that propagated as an unhandled ConnectError, crashing the route handler with a 500.

Wrap the call in try/catch and add a null guard, returning a 400 JSON response instead. This matches the existing pattern used by the SAML branch which already checks for a missing samlRequest.

Fixes: https://sentry.prod.env.datum.net/organizations/sentry/issues/2054/?alert_rule_id=19&alert_type=issue&notification_uuid=852b3420-6a90-49e9-8246-540ffe41b7d2&project=6&referrer=slack
