### PR TITLE
fix: treat already-handled device authorization as success

### DIFF
--- a/apps/login/src/lib/server/device.ts
+++ b/apps/login/src/lib/server/device.ts
@@ -11,10 +11,29 @@ export async function completeDeviceAuthorization(
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  // without the session, device auth request is denied
-  return authorizeOrDenyDeviceAuthorization({
-    serviceUrl,
-    deviceAuthorizationId,
-    session,
-  });
+  try {
+    // without the session, device auth request is denied
+    return await authorizeOrDenyDeviceAuthorization({
+      serviceUrl,
+      deviceAuthorizationId,
+      session,
+    });
+  } catch (error) {
+    // The /signedin page completes the device flow during a Server Component
+    // render, which the App Router may evaluate more than once per navigation
+    // (RSC refetch, prefetch, refresh, retries). The first call authorizes the
+    // grant successfully; subsequent calls fail with FAILED_PRECONDITION
+    // ("Device Authorization Request has already been handled"). Treat that as
+    // success so the user isn't shown a spurious error after a working login.
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === 9 /* FAILED_PRECONDITION */
+    ) {
+      return {};
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

Running `datumctl login --no-browser` succeeds, but the browser still shows a red error: `Device Authorization Request has already been handled (COMMAND-D30Jf)`. The login works, so the error is confusing and looks like a failure.

The cause is that the `/signedin` page completes the device flow inside a Server Component render by calling `completeDeviceAuthorization`. The App Router does not guarantee a render runs exactly once per navigation. It can re-evaluate the page on an RSC refetch, prefetch, refresh, or retry, and the manual `--no-browser` flow (where the verification URL is pasted into a browser) makes a second hit more likely. The first call authorizes the grant and finishes the CLI login. A second call then fails with `FAILED_PRECONDITION` because the request was already handled, and that error gets rendered as an alert.

This makes the completion idempotent: if the call fails with `FAILED_PRECONDITION` (code 9), we treat it as success rather than throwing. The grant already succeeded on the first call, so there is nothing to recover. This matches the existing pattern in `idp/[provider]/success/page.tsx`, which handles its one-time intent consumption the same way.

## Test plan

- [ ] `datumctl login --no-browser` in prod completes without showing the error alert on `/signedin`
- [ ] `datumctl login` (auto-browser) still completes normally
- [ ] Denying consent on the device screen still works (it routes through the same server action)
- [ ] A genuine non-precondition failure still surfaces an error

Closes #89