### PR TITLE
chore: drop rebuild branch from ci triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request: {}
   push:
-    branches: [refactor/auth-ui-rebuild, main]
+    branches: [main]
     paths-ignore:
       - 'docs/**'
       - 'README.md'


### PR DESCRIPTION
`refactor/auth-ui-rebuild` became `main` (#92) and is now deleted. Its builds come from `main`, so the trigger list no longer needs it — leaving it there would keep a workflow pointed at a ref that does not exist.

No behaviour change: pushes to `main` still publish the `v0.0.0-main-*` artifacts staging tracks, and GitHub releases still publish the stable `v1.x.y` artifacts production tracks.