### PR TITLE
fix(login): recover from a dead session instead of 500ing

### DIFF
--- a/app/modules/auth/session/session.ts
+++ b/app/modules/auth/session/session.ts
@@ -56,14 +56,24 @@ export function needsLivenessCheck(entry: SessionEntry): boolean {
   return entry.expirationTs === '';
 }
 
+/**
+ * Duplicate entries for the same identity can survive a superseding write (e.g. a stale entry
+ * left by an RP-initiated logout — /logout/success does NOT clear the `sessions` cookie — next
+ * to a fresh entry created moments later whose `organization` was resolved to an org id while
+ * the caller's raw query org was undefined; `undefined !== '<orgId>'` means the old entry's
+ * superseding filter never dropped it). When multiple entries match, prefer the MOST RECENT one
+ * (mirrors `mostRecent`'s changeTs comparison) rather than array order, so a shadowed stale entry
+ * never wins over the live one it was meant to replace.
+ */
 export function byLoginName(
   list: SessionEntry[],
   loginName: string,
   organization?: string
 ): SessionEntry | undefined {
-  return list.find(
+  const matches = list.filter(
     (s) => s.loginName === loginName && (!organization || s.organization === organization)
   );
+  return mostRecent(matches);
 }
 
 // Pure cookie-size guard (spec §7): keep newest sessions; evict oldest by changeTs

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: attempts.count
-#: app/routes/login/password.tsx:159
+#: app/routes/login/password.tsx:166
 msgid "{0, plural, one {# attempt remaining.} other {# attempts remaining.}}"
 msgstr "{0, plural, one {# attempt remaining.} other {# attempts remaining.}}"
 
@@ -195,7 +195,7 @@ msgstr "Continue"
 msgid "Continue with your provider"
 msgstr "Continue with your provider"
 
-#: app/routes/login/password.tsx:107
+#: app/routes/login/password.tsx:114
 msgid "Could not verify password"
 msgstr "Could not verify password"
 
@@ -306,8 +306,8 @@ msgstr "Enter your authenticator code"
 msgid "Enter your email code"
 msgstr "Enter your email code"
 
-#: app/routes/login/password.tsx:127
-#: app/routes/login/password.tsx:144
+#: app/routes/login/password.tsx:134
+#: app/routes/login/password.tsx:151
 msgid "Enter your password"
 msgstr "Enter your password"
 
@@ -319,7 +319,7 @@ msgstr "Enter your SMS code"
 msgid "Finish creating your account"
 msgstr "Finish creating your account"
 
-#: app/routes/login/password.tsx:190
+#: app/routes/login/password.tsx:197
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -441,7 +441,7 @@ msgstr "Phone"
 msgid "Phone sign-in isn't available — use your email or username."
 msgstr "Phone sign-in isn't available — use your email or username."
 
-#: app/routes/login/password.tsx:178
+#: app/routes/login/password.tsx:185
 #: app/utils/errors/auth-error-messages.tsx:27
 msgid "Please check your input and try again."
 msgstr "Please check your input and try again."
@@ -535,13 +535,13 @@ msgstr "Set up security key"
 msgid "Set up SMS one-time code"
 msgstr "Set up SMS one-time code"
 
-#: app/routes/login/password.tsx:183
+#: app/routes/login/password.tsx:190
 #: app/routes/signup/index.tsx:308
 #: app/routes/sso/ldap.tsx:82
 msgid "Sign in"
 msgstr "Sign in"
 
-#: app/routes/login/password.tsx:172
+#: app/routes/login/password.tsx:179
 #: app/routes/logout/success.tsx:22
 #: app/utils/errors/auth-error-recovery.tsx:47
 msgid "Sign in again"
@@ -829,7 +829,7 @@ msgstr "You're almost done! <0>{loginName}</0>"
 msgid "You've been signed out"
 msgstr "You've been signed out"
 
-#: app/routes/login/password.tsx:154
+#: app/routes/login/password.tsx:161
 msgid "Your account is temporarily locked after too many attempts."
 msgstr "Your account is temporarily locked after too many attempts."
 
@@ -853,7 +853,7 @@ msgstr "Your password has expired. Please reset it to continue."
 msgid "Your session has ended and you've been securely signed out of Datum. You can safely close this tab, or sign back in any time to pick up where you left off."
 msgstr "Your session has ended and you've been securely signed out of Datum. You can safely close this tab, or sign back in any time to pick up where you left off."
 
-#: app/routes/login/password.tsx:170
+#: app/routes/login/password.tsx:177
 #: app/utils/errors/auth-error-messages.tsx:56
 msgid "Your session has expired."
 msgstr "Your session has expired."

--- a/app/resources/login/login.service.ts
+++ b/app/resources/login/login.service.ts
@@ -17,10 +17,11 @@ import { idpTypeToSlug } from '@/modules/auth/idp-slug';
 import {
   addSession,
   byLoginName,
+  removeSession,
   sessionEntryFromSession,
   type SessionEntry,
 } from '@/modules/auth/session/cookie';
-import type { LoginSettings } from '@/modules/auth/types';
+import type { LoginSettings, ProviderErrorCode } from '@/modules/auth/types';
 import { ProviderError } from '@/modules/auth/types';
 import { decideAfterIdentifier } from '@/resources/login/login-decision';
 import { isEmailLike } from '@/resources/login/login.schema';
@@ -369,8 +370,23 @@ export interface VerifyLoginPasswordCredentialFailure {
 
 export type VerifyLoginPasswordResult =
   | VerifyLoginPasswordRedirect
-  | { ok: false; error: 'SESSION_EXPIRED' }
+  // `sessions` is populated ONLY by the dead-session-recovery branch below (a pruned list the
+  // route must re-serialize into the cookie); the "no entry found" early-return below has
+  // nothing to prune, so it omits it (the route makes no cookie change in that case).
+  | { ok: false; error: 'SESSION_EXPIRED'; sessions?: SessionEntry[] }
   | VerifyLoginPasswordCredentialFailure;
+
+// updateSession failures that are genuinely transient backend problems (NOT a dead session): these
+// still throw so real outages stay visible/alertable. Every OTHER ProviderError — including
+// ALREADY_DONE, which is how normalizeError classifies Zitadel's real
+// "[failed_precondition] Session already terminated" response (see mappers.ts) — means the
+// stored session token is stale/revoked, not a live backend failure. Mirrors the account-switch
+// precedent (session.service.ts's SWITCH_TRANSIENT_CODES + reauthRedirect).
+const TRANSIENT_CODES = new Set<ProviderErrorCode>([
+  'UNAVAILABLE',
+  'DEADLINE_EXCEEDED',
+  'RATE_LIMITED',
+]);
 
 /**
  * Password step: look up the ceremony session entry (by loginName, from the SIGNED
@@ -386,8 +402,12 @@ export type VerifyLoginPasswordResult =
  * (which calls createCallback and redirects back to the OIDC client). We surface the
  * authorize target with the same persisted session list.
  *
- * INVALID_CREDENTIALS is mapped to a typed failure (carrying failed/max attempts);
- * other ProviderErrors re-throw. Never logs the password.
+ * INVALID_CREDENTIALS is mapped to a typed failure (carrying failed/max attempts).
+ * DEAD-SESSION RECOVERY: any other NON-transient ProviderError means the ceremony entry's
+ * session is dead server-side (e.g. a stale entry left by an RP-initiated logout, since
+ * /logout/success does not clear the `sessions` cookie) — prune it and surface a recoverable
+ * SESSION_EXPIRED instead of letting the error escape to the route's uncaught-error boundary.
+ * Only genuinely transient codes still re-throw. Never logs the password.
  */
 export async function verifyLoginPassword(
   provider: AuthProvider,
@@ -410,6 +430,17 @@ export async function verifyLoginPassword(
         failedAttempts: error.detail?.failedAttempts,
         maxAttempts: error.detail?.maxAttempts,
       };
+    }
+    // Dead-session recovery (see TRANSIENT_CODES doc above): a non-transient ProviderError here
+    // means the ceremony entry's session is dead, not a live outage. Prune it and hand the
+    // pruned list back so the route can re-serialize the cookie without the stale entry.
+    if (error instanceof ProviderError && !TRANSIENT_CODES.has(error.code)) {
+      logAuthEvent('password_check', 'failure', {
+        actor: hashActor(loginName),
+        reason: error.code,
+        recovery: 'session_expired',
+      });
+      return { ok: false, error: 'SESSION_EXPIRED', sessions: removeSession(list, entry.id) };
     }
     throw error;
   }

--- a/app/routes/login/password.tsx
+++ b/app/routes/login/password.tsx
@@ -60,7 +60,14 @@ export async function action({ request }: ActionFunctionArgs) {
 
   if (!result.ok) {
     if (result.error === 'SESSION_EXPIRED') {
-      return data({ error: 'SESSION_EXPIRED' as const }, { status: 400 });
+      // Dead-session recovery (see login.service.ts): when the stale entry was pruned, thread
+      // the pruned list back into the cookie so the browser actually drops it — otherwise the
+      // same dead entry would keep shadowing the fresh one on every retry.
+      const headers = new Headers();
+      if (result.sessions) {
+        headers.append('set-cookie', await serializeSessions(result.sessions));
+      }
+      return data({ error: 'SESSION_EXPIRED' as const }, { status: 400, headers });
     }
     return data(
       {

--- a/cypress/component/modules/auth/providers/zitadel/mappers.cy.ts
+++ b/cypress/component/modules/auth/providers/zitadel/mappers.cy.ts
@@ -40,6 +40,18 @@ describe('normalizeError (ConnectError → ProviderError)', () => {
     // FAILED_PRECONDITION/UNKNOWN.
     const mapped = normalizeError({ code: 9, message: 'totp already verified' });
     expect(mapped.code).to.equal('ALREADY_DONE');
+
+    // Dead-session-recovery trap (fix/dead-session-recovery): the REAL Zitadel staging message
+    // for updateSession on a session an RP-initiated logout already terminated is
+    // FailedPrecondition/9 with "Session already terminated" — normalizeError MUST classify
+    // this as ALREADY_DONE, NOT FAILED_PRECONDITION. login.service.ts's dead-session recovery
+    // (verifyLoginPassword) keys off this exact classification, so a "fix" that reclassifies
+    // code 9 + "already" as FAILED_PRECONDITION would silently break it.
+    const deadSession = normalizeError({
+      code: 9,
+      message: '[failed_precondition] Session already terminated (COMMAND-Hewfq)',
+    });
+    expect(deadSession.code).to.equal('ALREADY_DONE');
   });
 });
 

--- a/cypress/component/modules/auth/session/session.cy.ts
+++ b/cypress/component/modules/auth/session/session.cy.ts
@@ -84,6 +84,36 @@ describe('byLoginName', () => {
     expect(byLoginName([alice], 'alice@acme.test', 'other-org')).to.be.undefined;
     expect(byLoginName([alice, bob], 'charlie@acme.test')).to.be.undefined;
   });
+
+  // Fix B (fix/dead-session-recovery): a stale ceremony entry left behind by an RP-initiated
+  // logout (organization: undefined, the caller's RAW query org) can shadow a fresh entry
+  // created moments later by signup/resolveIdentifier (organization: the RESOLVED org id) —
+  // `undefined !== '<orgId>'` so login.service.ts's prior-entry filter never supersedes it, and
+  // addSession appends the fresh entry AFTER the stale one. When the caller queries with NO
+  // organization (the common case — VerifyLoginPasswordInput.organization is usually undefined),
+  // both entries match by loginName; byLoginName must prefer the MOST RECENT (by changeTs, the
+  // same comparison mostRecent uses) rather than the first (insertion-order) match.
+  it('prefers the MOST RECENT match when duplicate loginName entries differ only by organization (stale vs. resolved-org shadowing)', () => {
+    const stale: SessionEntry = {
+      ...base,
+      id: 'stale',
+      loginName: 'bob@acme.test',
+      organization: undefined,
+      changeTs: '1',
+    };
+    const fresh: SessionEntry = {
+      ...base,
+      id: 'fresh',
+      loginName: 'bob@acme.test',
+      organization: 'org-123',
+      changeTs: '2',
+    };
+    // Stale inserted first, fresh appended after (mirrors addSession ordering) — first-match
+    // (pre-fix) would return `stale`; recency-based lookup must return `fresh`.
+    expect(byLoginName([stale, fresh], 'bob@acme.test')).to.deep.equal(fresh);
+    // Order-independent: the fix must not be a positional accident.
+    expect(byLoginName([fresh, stale], 'bob@acme.test')).to.deep.equal(fresh);
+  });
 });
 
 describe('needsLivenessCheck', () => {

--- a/cypress/component/resources/login/dead-session-recovery.cy.ts
+++ b/cypress/component/resources/login/dead-session-recovery.cy.ts
@@ -1,0 +1,115 @@
+// cypress/component/resources/login/dead-session-recovery.cy.ts
+//
+// fix/dead-session-recovery — root-caused from real staging logs:
+//
+// 1) A user holding an active session for identity A opens the auth app and registers a NEW
+//    account B. signup.service.ts's persistSession APPENDS session B's entry via addSession;
+//    identity A's stale entry is left in the `sessions` cookie.
+// 2) RP-initiated logout terminates the Zitadel session server-side, but the browser lands on
+//    /id/logout/success, which does NOT clear the `sessions` cookie (only /id/logout does) — so
+//    auth-ui keeps a {id, token} for a session Zitadel has already terminated.
+// 3) login.service.ts's byLoginName lookup can return that stale entry (see
+//    modules/auth/session/session.cy.ts Fix B spec for the shadowing mechanics).
+// 4) verifyLoginPassword calls provider.updateSession(entry.id, entry.token, ...) with the dead
+//    id → Zitadel throws FailedPrecondition/9 "Session already terminated", which
+//    mappers.ts#normalizeError classifies as ALREADY_DONE (NOT FAILED_PRECONDITION — see
+//    mappers.cy.ts). Before this fix, verifyLoginPassword re-threw anything that wasn't
+//    INVALID_CREDENTIALS, and login/password.tsx has no try/catch → root ErrorBoundary → 500.
+//
+// Fix: any NON-transient ProviderError from updateSession means the stored session is dead, not
+// a live outage — prune the stale entry (removeSession) and return a recoverable SESSION_EXPIRED
+// instead of throwing. Transient codes (UNAVAILABLE/DEADLINE_EXCEEDED/RATE_LIMITED) are real
+// outages and must still throw (mirrors the account-switch precedent: session.service.ts's
+// SWITCH_TRANSIENT_CODES allowlist + reauthRedirect).
+import { FakeAuthProvider } from '@/modules/auth/providers/fake/fake-provider';
+import type { SessionEntry } from '@/modules/auth/session/cookie';
+import { ProviderError } from '@/modules/auth/types';
+import { verifyLoginPassword } from '@/resources/login';
+
+const LOGIN_NAME = 'bob@acme.test';
+
+const staleEntry: SessionEntry = {
+  id: 'sess-stale',
+  token: 'tok-stale',
+  loginName: LOGIN_NAME,
+  creationTs: '1',
+  expirationTs: '9999999999999',
+  changeTs: '1',
+};
+
+function makeProvider(): FakeAuthProvider {
+  const provider = new FakeAuthProvider({
+    users: [{ id: 'u1', loginName: LOGIN_NAME }],
+    passwords: { u1: 'hunter2' },
+    authMethods: { u1: ['password'] },
+  });
+  // Seed the live session backing `staleEntry` so the REAL (unscripted) updateSession — exercised
+  // by the INVALID_CREDENTIALS spec below — finds a live session rather than NOT_FOUND.
+  provider.seedLiveSession({
+    id: staleEntry.id,
+    token: staleEntry.token,
+    user: { id: 'u1', loginName: LOGIN_NAME },
+  });
+  return provider;
+}
+
+/** Script updateSession to throw a given ProviderError on every call (Fake-only monkey-patch —
+ * same seam the node harness uses for scripted overrides the fake's built-in scripting doesn't
+ * cover, e.g. cypress/support/node/harness.ts's `provider.getSession = (async () => {...})`). */
+function scriptUpdateSessionThrow(provider: FakeAuthProvider, error: ProviderError): void {
+  provider.updateSession = (async () => {
+    throw error;
+  }) as FakeAuthProvider['updateSession'];
+}
+
+describe('verifyLoginPassword — dead-session recovery (stale entry survives RP-initiated logout)', () => {
+  it('a non-transient ProviderError (ALREADY_DONE — the real "Session already terminated" classification) prunes the stale entry and returns SESSION_EXPIRED instead of throwing', async () => {
+    const fake = makeProvider();
+    scriptUpdateSessionThrow(
+      fake,
+      new ProviderError(
+        'ALREADY_DONE',
+        '[failed_precondition] Session already terminated (COMMAND-Hewfq)'
+      )
+    );
+
+    const result = await verifyLoginPassword(fake, [staleEntry], {
+      loginName: LOGIN_NAME,
+      password: 'hunter2',
+    });
+
+    expect(result.ok).to.equal(false);
+    if (result.ok) return;
+    expect(result.error).to.equal('SESSION_EXPIRED');
+    // The stale entry must be pruned from the returned sessions (so the route can emit a
+    // cookie that no longer carries it) — not silently left in place.
+    expect('sessions' in result ? result.sessions : undefined).to.deep.equal([]);
+  });
+
+  it('a transient ProviderError (UNAVAILABLE) still throws — a real outage must never be silently swallowed as a dead session', async () => {
+    const fake = makeProvider();
+    scriptUpdateSessionThrow(fake, new ProviderError('UNAVAILABLE', 'zitadel unreachable'));
+
+    let caught: unknown;
+    try {
+      await verifyLoginPassword(fake, [staleEntry], { loginName: LOGIN_NAME, password: 'hunter2' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ProviderError);
+    expect((caught as ProviderError).code).to.equal('UNAVAILABLE');
+  });
+
+  it('INVALID_CREDENTIALS keeps its existing dedicated branch (untouched by the recovery path)', async () => {
+    const fake = makeProvider();
+    // wrong password against the REAL fake updateSession (not scripted) — exercises the
+    // pre-existing branch to prove the new recovery logic doesn't shadow it.
+    const result = await verifyLoginPassword(fake, [staleEntry], {
+      loginName: LOGIN_NAME,
+      password: 'WRONG',
+    });
+    expect(result.ok).to.equal(false);
+    if (result.ok) return;
+    expect(result.error).to.equal('INVALID_CREDENTIALS');
+  });
+});


### PR DESCRIPTION
## Problem

A teammate registering with email + password on staging hit an error page, then landed on `/id/logout/success`. Signup itself worked (user created and provisioned) — the failure was on the *next* login.

He had an active session for a different identity when he opened `/id/signup` directly (not through an app). Six things then line up:

1. Signup **appends** the new session to the `sessions` cookie without pruning the old one → cookie holds a stale entry A and a fresh entry B.
2. The RP logout terminates the Zitadel session, but **`/id/logout/success` does not clear the cookie** — only `/id/logout` does. Entry A survives, now pointing at a dead Zitadel session.
3. `byLoginName` returned the **first** match, so stale A could shadow fresh B. The filter meant to supersede A never fired: it compares the raw query org against an entry whose org was already resolved to an id.
4. Password login hands A's dead session id to `updateSession`.
5. Zitadel answers **`Session already terminated`** — gRPC code 9 with "already" in the message, which `normalizeError` classifies as **`ALREADY_DONE`**, not `FAILED_PRECONDITION`.
6. `login.service.ts` only caught `INVALID_CREDENTIALS`, so `ALREADY_DONE` was rethrown → no try/catch in the route → root ErrorBoundary → **500**.

```
ProviderError: [failed_precondition] Session already terminated (COMMAND-Hewfq)
  at normalizeError (auth-context.server:373)
```

## Fix

**`login.service.ts` — treat a non-transient `updateSession` failure as a dead session.** Prune the entry and return a recoverable `SESSION_EXPIRED` (the route already renders that inline) instead of throwing. Uses an inverted allowlist so transient codes (`UNAVAILABLE`, `DEADLINE_EXCEEDED`, `RATE_LIMITED`) still throw — a real Zitadel outage stays loud instead of masquerading as an expired session. This mirrors `SWITCH_TRANSIENT_CODES` in `session.service.ts`.

**`password.tsx` — thread the pruned list back into the cookie.** Without this the stale entry survives and the user loops.

**`session.ts` — `byLoginName` now prefers the most recent match**, so a stale entry can't shadow a fresh one regardless of the org-shape asymmetry.

## Scope

Deliberately **not** in this PR:

- **Clearing the cookie at `/logout/success`** — would log multi-account users out of every account on an RP-initiated logout of one.
- **Changing signup's append behaviour** — multi-account is a supported flow; the bug is that we don't recover from a dead entry, not that a second entry exists.

Both are worth a follow-up discussion; neither is needed to stop the 500.

## Tests

TDD, red → green. `bun run test:unit` — **511/511 passing**.

- `cypress/component/resources/login/dead-session-recovery.cy.ts` (new) — dead session → `SESSION_EXPIRED` + pruned list; transient codes still throw.
- `session.cy.ts` — the stale-vs-resolved-org shadowing case.
- `mappers.cy.ts` — **regression guard** pinning `code 9 + "already"` → `ALREADY_DONE` (and code 9 without it → `FAILED_PRECONDITION`). This mapping is the trap that made the bug non-obvious; the guard stops a future edit from silently re-breaking the recovery path.

## Verifying on staging

Sign in as user A → go directly to `/id/signup` → register user B → sign out → sign in as B with the password. Before: error page. After: the password step succeeds (or, if the session is genuinely gone, shows the inline "session expired" message and recovers on retry rather than 500ing).
