### PR TITLE
fix: fire signup_submitted when email verification is off

### DIFF
--- a/app/resources/signup/signup.service.ts
+++ b/app/resources/signup/signup.service.ts
@@ -310,6 +310,13 @@ async function runEnumerationSafeRegister(
     const sessions = await retryOnceIfNotFound(() => persistSession(user));
     // Audit shape DIVERGES per path — parameterized, never collapsed to one event.
     cfg.noVerifySuccessAudit(user);
+    // Fired server-side (not the client trackAuthEvent) because this path redirects the
+    // browser straight to postRegisterStep's target without ever rendering the
+    // "Check your email" page that carries the client-side TrackOnMount.
+    trackServerEvent('signup_submitted', {
+      userId: user.id,
+      properties: { channel: cfg.hasPassword ? 'password' : 'passkey' },
+    });
     const target = postRegisterStep({
       hasPassword: cfg.hasPassword,
       emailVerified: false,


### PR DESCRIPTION
## Summary

Confirmed live in staging: a real password signup produced no `signup_submitted` event at all — the event log jumped straight from the `/signup/password` page hit to landing in `/onboarding/profile`, with nothing in between.

## Root cause

`TrackOnMount(signup_submitted)` only renders on `/signup/password`'s "Check your email" screen, which is the branch taken when email verification is required. Staging runs with `EMAIL_VERIFICATION=false`, so registration takes the other branch in `runEnumerationSafeRegister` and redirects straight to `postRegisterStep`'s target — the browser never renders a page that could fire the client-side event.

## Changes

`runEnumerationSafeRegister`'s verification-not-required branch now calls `trackServerEvent('signup_submitted', ...)` directly, mirroring the existing IdP call in this same file and its rationale (the browser never renders a trackable page). Channel is `'password'` or `'passkey'` based on `cfg.hasPassword`, since both `registerWithPassword` and `registerPasskeyFirst` share this function.

Typecheck, lint, and prettier all pass. No existing unit tests cover `signup.service.ts` (it has zero prior coverage), and the outbound call is a server-side `fetch()` that Cypress's browser-level `cy.intercept()` can't observe, so this is verified live rather than via a new test harness.
