### PR TITLE
chore(deps): override nanoid to ^3.3.17 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,7 @@
     "dompurify": "^3.4.13",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",
+    "nanoid": "^3.3.17",
     "postcss": "^8.5.25",
     "undici": "^7.29.0",
   },
@@ -1451,7 +1452,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "overrides": {
     "axios": "^1.19.0",
     "postcss": "^8.5.25",
+    "nanoid": "^3.3.17",
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@opentelemetry/core": "2.8.0",
     "@opentelemetry/resources": "2.8.0",


### PR DESCRIPTION
`bun audit` fails on `nanoid <3.3.17` (**high** — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), custom generators can loop indefinitely when size is zero), which fails the Supply Chain job and cascades into Final Status Check.

**Transitive dev/build tooling only** — nothing reaches shipped runtime code:

```
vite > postcss > nanoid
@trivago/prettier-plugin-sort-imports > @vue/compiler-sfc > postcss > nanoid
madge > dependency-tree > precinct > detective-postcss > postcss > nanoid
cypress-split > find-cypress-specs > spec-change > ... > postcss > nanoid
```

Pinned through the existing `overrides` block, matching how `postcss`, `undici`, `form-data` and `dompurify` are already handled in this repo. Resolves to `nanoid@3.3.18`.

**Why now:** the advisory postdates the last `main` CI run (Aug 5), so **every open PR fails this job** until this lands — it is not specific to any feature branch.

### Verified
- `bun audit` → **No vulnerabilities found** (was 1 high)
- `bun run build` → clean
- Diff is 3 lines across `package.json` + `bun.lock`; no direct dependency added